### PR TITLE
fix typo

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,8 +70,8 @@ exports.parseFullName = function parseFullName(
                 namePartWords[j].slice(3).toLowerCase();
             } else if (
                 namePartLabels[j] === 'suffix' &&
-                nameParts[j].slice(-1) !== '.' &&
-                !suffixList.indexOf(nameParts[j].toLowerCase())
+                namePartWords[j].slice(-1) !== '.' &&
+                !suffixList.indexOf(namePartWords[j].toLowerCase())
               ) { // Convert suffix abbreviations to UPPER CASE
               if ( namePartWords[j] === namePartWords[j].toLowerCase() ) {
                 namePartWords[j] = namePartWords[j].toUpperCase();

--- a/test/index.js
+++ b/test/index.js
@@ -15,6 +15,8 @@ var verifyName = function(nameToCheck, partsToCheck) {
   }
 };
 
+
+
 describe('parse-full-name', function() {
   describe('parseFullName', function() {
     it('parses first names', function() {
@@ -68,6 +70,9 @@ describe('parse-full-name', function() {
         ['','Orenthal','James','Simpson','O. J.','',[]]);
       verifyName(parseFullName('Simpson, [O. J.] Orenthal James'),
         ['','Orenthal','James','Simpson','O. J.','',[]]);
+      verifyName(parseFullName('Strippoli, Charles J (HM Home and Community Svcs LLC)'),
+        ['','Charles','J','Strippoli','HM Home and Community Svcs LLC','',[]]);
+        
     });
     it('parses known suffixes', function() {
       verifyName(parseFullName('Sammy Davis, Jr.'),


### PR DESCRIPTION
Attempting to parse `Strippoli, Charles J (HM Home and Community Svcs LLC)` would  bug out in an else if condition, nameParts doesn't exist within the scope of this `else if` block - it has to be updated to namePartWords

Input: `Strippoli, Charles J (HM Home and Community Svcs LLC)`
Expected Output: 
```
{
  title: '',
  first: 'Charles',
  middle: 'J',
  last: 'Strippoli',
  nick: 'HM Home and Community Svcs LLC',
  suffix: '',
  error: []
}
```